### PR TITLE
Resize all images to prevent issues when displaying on qlabel

### DIFF
--- a/detailviewerwindow.ui
+++ b/detailviewerwindow.ui
@@ -31,6 +31,9 @@
    <property name="text">
     <string>Image Window</string>
    </property>
+   <property name="scaledContents">
+    <bool>true</bool>
+   </property>
    <property name="alignment">
     <set>Qt::AlignCenter</set>
    </property>


### PR DESCRIPTION
1. Collab image and full images are now resized to 1920 width with initial aspect ratio
This is done, so that when later we convert them to QImage and QPixmap there won't be issues, such as distortion, greyscale or crashing the app. Other way of solving those issues would be to set correct step when converting to QImage, but it seemed too troublesome...
2. Fixed issue with timeLabel showing wrong time (due to adding new collab image as first)
3. Set QLabel to scale its contents
4. Added detecting .wmv videos
5. Extended some logging